### PR TITLE
fix bot didnt update hero info after get reward from quest in offical…

### DIFF
--- a/TbsCore/Tasks/LowLevel/ClaimBeginnerTask2021.cs
+++ b/TbsCore/Tasks/LowLevel/ClaimBeginnerTask2021.cs
@@ -24,7 +24,7 @@ namespace TbsCore.Tasks.LowLevel
                 await ClaimRewards(acc);
             }
 
-            acc.Tasks.Add(new HeroUpdateInfo() { ExecuteAt = DateTime.Now }, true);
+            acc.Tasks.Add(new HeroUpdateInfo() { ExecuteAt = DateTime.Now });
 
             return TaskRes.Executed;
         }


### PR DESCRIPTION
- fix bot click play button but because ads is autoplay, bot pause it instead
- fix train settler cannot find settler box in ttwars
- fix bot forget storage building is upgrading and keep adding storage upgrade when storage is too low
- fix hero use resources like human

If you like my work, you can donate to me through ko-fi.com/vinaghost